### PR TITLE
Fix cheese with learning treasures early

### DIFF
--- a/src/components/Tracker/Layout.svelte
+++ b/src/components/Tracker/Layout.svelte
@@ -96,7 +96,7 @@
         {#each formattedLocations as location, i (location.id)}
           <Row style={location.found && 'background-color: #ebfbe9;'}>
             <Cell>{location.description}</Cell>
-            <Cell>
+            <Cell style="text-align: center">
               <Checkbox
                 on:click={() => handleCheckboxClick(i)}
                 valueKey={location.id}
@@ -105,7 +105,7 @@
             <Cell style="max-width: 350px; white-space: normal;">
               <span class={`${!location.found ? 'hidden' : ''}`}>
                 <span class={`${(location.result === 'TREASURE!!!' && location.found) ? 'gold' : ''}`}>
-                  {location.found ? location.result : 'Find the location to see if there\'s treasure'}
+                  {location.found ? location.result : 'Location not found'}
                 </span>
               </span>
             </Cell>
@@ -130,7 +130,7 @@
           <Row style={defeated.includes(rival.id) ? 'background-color: #ebfbe9;' : ''}>
             <Cell>{rival.location}</Cell>
             <Cell>{rival.name}{#if rival.missable}{@html '<span style="color: red;">*</span>'}{/if}</Cell>
-            <Cell>
+            <Cell style="text-align: center">
               <Checkbox
                 on:click={() => handleRivalDefeated(rival.id)}
                 valueKey={rival.name}


### PR DESCRIPTION
If you shrink the width of the browser, it was easy to see which locations had hints because their text was longer, causing the cell to increase in height. This has been fixed with every result cell getting a static "Location not found" until the location checkbox has been checked.

It does mean the cell expands on click, but I have a max-width there, so I'm not too worried about that.

This PR also centers the checkboxes in their cell