### PR TITLE
Fix bug with right clicking mon and empty status

### DIFF
--- a/src/constants/minesweeper.js
+++ b/src/constants/minesweeper.js
@@ -4,7 +4,7 @@ const STATUS = {
   SAFE: 'safe',
   SEEN: 'seen',
   OWNED: 'owned',
-  MINED: 'mined',
+  MINED: 'excavated',
   EXPLODED: 'exploded',
   ORIGIN_EXPLODED: 'origin_exploded',
 };

--- a/src/routes/minesweeper/+page.svelte
+++ b/src/routes/minesweeper/+page.svelte
@@ -134,15 +134,22 @@
 	 * @param {number} monIndex
 	 */
   function contextSelectMon(monIndex) {
-    const currentStatus = statusList[monIndex];
+    let currentStatus = statusList[monIndex];
+
+    // Replace empty status
+    if (currentStatus === STATUS.EMPTY) {
+      currentStatus = '';
+    }
+
     if (![STATUS.EXPLODED, STATUS.MINED, STATUS.ORIGIN_EXPLODED].includes(currentStatus)) {
       // Iterate through following chain: FLAGGED -> SAFE -> Neither
       if (currentStatus.includes(STATUS.FLAGGED)) {
         statusList[monIndex] = currentStatus.replace(STATUS.FLAGGED, STATUS.SAFE);
       } else if (currentStatus.includes(STATUS.SAFE)) {
-        statusList[monIndex] = currentStatus.replace(STATUS.SAFE, '').trim();
+        const newStatus = currentStatus.replace(STATUS.SAFE, '').trim();
+        statusList[monIndex] = newStatus !== '' ? newStatus : STATUS.EMPTY;
       } else {
-        statusList[monIndex] = currentStatus.concat(' ', STATUS.FLAGGED);
+        statusList[monIndex] = currentStatus.concat(' ', STATUS.FLAGGED).trim();
       }
     }
   }


### PR DESCRIPTION
Right-clicking would change an Empty status mon from `UNKNOWN` to `UNKNOWN FLAGGED`. This fixes that.

I also changed the displayed verbiage for an excavated mon to match the verbiage on the action button.