### PR TITLE
Maintain image aspect ratio in the points tracker

### DIFF
--- a/src/routes/points/+page.svelte
+++ b/src/routes/points/+page.svelte
@@ -772,6 +772,7 @@
     border: 1px solid transparent;
     height: 32px;
     width: 32px;
+    object-fit: contain;
   }
 
   .region-section img {


### PR DESCRIPTION
Old Behaviour:
<img width="262" alt="Screenshot 2023-04-16 at 12 14 16 PM" src="https://user-images.githubusercontent.com/22305506/232333307-090df35a-b40d-41ec-962a-fd54818a5dbd.png">
New Behaviour:
<img width="266" alt="Screenshot 2023-04-16 at 12 14 03 PM" src="https://user-images.githubusercontent.com/22305506/232333313-d299a78d-364b-48ad-9201-060d93c69cca.png">
