### PR TITLE
Fix sequential items

### DIFF
--- a/src/lib/extractRegionsFromSpoiler.js
+++ b/src/lib/extractRegionsFromSpoiler.js
@@ -24,11 +24,11 @@ function extractRegionsFromSpoiler(spoilerFileText, keyItems) {
   const modifierStartIndex = spoilerLines.findIndex(line => line.includes('Modifiers:'));
   const modifierEndIndex = spoilerLines.findIndex(line => line.includes('RNG Seed:'));
   const modifierLines = spoilerLines.slice(modifierStartIndex, modifierEndIndex).join('').replace(/\s\s/g, ' ');
-  const solutionLines = `${spoilerLines.slice(solutionStartIndex, solutionEndIndex).join(';')};`;
+  const solutionLines = `${spoilerLines.slice(solutionStartIndex, solutionEndIndex).join(';;')};`;
   const uselessStuffLines = `${spoilerLines.slice(
     solutionEndIndex,
     spoilerLines.findIndex(line => line.includes('Xtra Stuff:')),
-  ).join(';')};`;
+  ).join(';;')};`;
   // This is likely not needed anymore but keeping it around just in case
   // const upgradeLines = spoilerLines.slice(spoilerLines.findIndex(line => line.includes('Xtra Upgrades:')));
 


### PR DESCRIPTION
The regex being used to parse items looks for semicolons on either side of the line containing the item. Once a semicolon has been matched it is ignored for future matches for that item. Because lines were only separated by 1 semicolon, if items of the same type were right next to each other in the spoiler log, every second item of that type wouldn't get matched because it's leading semicolon had already been matched as a trailing semicolon for the previous line. This fixes that by separating lines with 2 semicolons.