### PR TITLE
Hotfix: End solution block parsing on line after Zephyr Badge

### DIFF
--- a/src/lib/extractRegionsFromSpoiler.js
+++ b/src/lib/extractRegionsFromSpoiler.js
@@ -20,13 +20,14 @@ function extractRegionsFromSpoiler(spoilerFileText, keyItems) {
   const spoilerLines = spoilerFileText.split('\r\n');
   const rngSeed = spoilerLines.find(line => line.includes('RNG Seed:'))?.replace('RNG Seed: ', '');
   const solutionStartIndex = spoilerLines.findIndex(line => line.includes('Solution:'));
-  const solutionEndIndex = spoilerLines.findIndex(line => line.includes('Useless Stuff:'));
+  const solutionEndIndex = spoilerLines.findIndex(line => line.includes('Zephyr Badge:')) + 1;
+  const uselessStuffStartIndex = spoilerLines.findIndex(line => line.includes('Useless Stuff:'));
   const modifierStartIndex = spoilerLines.findIndex(line => line.includes('Modifiers:'));
   const modifierEndIndex = spoilerLines.findIndex(line => line.includes('RNG Seed:'));
   const modifierLines = spoilerLines.slice(modifierStartIndex, modifierEndIndex).join('').replace(/\s\s/g, ' ');
   const solutionLines = `${spoilerLines.slice(solutionStartIndex, solutionEndIndex).join(';;')};`;
   const uselessStuffLines = `${spoilerLines.slice(
-    solutionEndIndex,
+    uselessStuffStartIndex,
     spoilerLines.findIndex(line => line.includes('Xtra Stuff:')),
   ).join(';;')};`;
   // This is likely not needed anymore but keeping it around just in case


### PR DESCRIPTION
This is to fix a parsing bug because the check location for the Map Card has the same name as a key item (ie. "Map Card"). The bug basically came about because of a new section in the spoiler called Solution_Order that appears immediately after the Solution section and because the Map Card check had a key item at it.

I've changed this so we essentially ignore the Solution_Order section and any other new section after the Solution. I can't really do anything about the Map Card location check name and it isn't super necessary to change.