### PR TITLE
Switch click functionality of both hint trackers

### DIFF
--- a/src/components/Tracker/ClassicRegion.svelte
+++ b/src/components/Tracker/ClassicRegion.svelte
@@ -116,27 +116,7 @@
     selectedFoundItem = {};
   }
 
-  function handleFoundItemClick(event, item, currBasketIndex) {
-    event.stopPropagation();
-    selectedAvailableItem = {};
-    selectedFoundItem = {
-      ...item,
-      currBasketIndex,
-    };
-  }
-
-  function handleAvailableItemClick(event, item, currBasketIndex) {
-    event.stopPropagation();
-    selectedAvailableItem = {
-      ...item,
-      currBasketIndex,
-    };
-    selectedFoundItem = {};
-  }
-
-  function toggleHighlightItem(event, basketIndex, itemIndex) {
-    event.preventDefault();
-
+  function toggleHighlightItem(basketIndex, itemIndex) {
     let highlightedItem = {
       ...baskets[basketIndex].items[itemIndex],
     };
@@ -148,6 +128,46 @@
 
     baskets[basketIndex].items[itemIndex] = highlightedItem;
     baskets = baskets;
+  }
+
+  function handleFoundItemClick(event, item, currBasketIndex, currItemIndex) {
+    event.stopPropagation();
+    selectedAvailableItem = {};
+
+    if (selectedFoundItem?.id === item.id && selectedFoundItem?.currBasketIndex === currBasketIndex && selectedFoundItem?.currItemIndex === currItemIndex) {
+      toggleHighlightItem(currBasketIndex, currItemIndex);
+      selectedFoundItem = {};
+    } else {
+      selectedFoundItem = {
+        ...item,
+        currBasketIndex,
+        currItemIndex,
+      };
+    }
+  }
+
+  function handleAvailableItemClick(event, item, currBasketIndex) {
+    event.stopPropagation();
+    selectedAvailableItem = {
+      ...item,
+      currBasketIndex,
+    };
+    selectedFoundItem = {};
+  }
+
+  function handleClearItem(event, basketIndex, itemIndex) {
+    event.preventDefault();
+
+    const [removedItem] = baskets[basketIndex].items.splice(itemIndex, 1);
+    const targetBasket = baskets.find(basket => basket.type === 'item' && basket.name === removedItem.points.toString());
+
+    // Add the item to the drop target basket.
+    targetBasket.items.push(removedItem);
+    baskets = baskets;
+
+    handleCheckToExposeRegion(baskets[basketIndex], targetBasket, removedItem);
+    selectedAvailableItem = {};
+    selectedFoundItem = {};
   }
 
   function handleOutsideRegionTableClick(e) {
@@ -226,12 +246,16 @@
                         class="draggableIcon"
                         draggable={true}
                         on:dragstart={(e) => dragStart(e, i, itemIndex)}
-                        on:click={(e) => handleFoundItemClick(e, item, i)}
-                        on:keypress={(e) => handleFoundItemClick(e, item, i)}
-                        on:contextmenu={(e) => toggleHighlightItem(e, i, itemIndex)}
+                        on:click={(e) => handleFoundItemClick(e, item, i, itemIndex)}
+                        on:keypress={(e) => handleFoundItemClick(e, item, i, itemIndex)}
+                        on:contextmenu={(e) => handleClearItem(e, i, itemIndex)}
                       >
                         <img
-                          class:selected={selectedFoundItem?.id === item.id}
+                          class:selected={
+                            selectedFoundItem?.id === item.id &&
+                            selectedFoundItem?.currBasketIndex === i &&
+                            selectedFoundItem?.currItemIndex === itemIndex
+                          }
                           class:highlighted={item.highlighted}
                           src={`/keyItems/${item.id}.png`}
                           alt={item.name}

--- a/src/components/Tracker/CompactRegion1.svelte
+++ b/src/components/Tracker/CompactRegion1.svelte
@@ -143,14 +143,35 @@
     selectedFoundItem = {};
   }
 
+  function toggleHighlightItem(basketIndex, itemIndex) {
+    let highlightedItem = {
+      ...baskets[basketIndex].items[itemIndex],
+    };
+
+    highlightedItem = {
+      ...highlightedItem,
+      highlighted: !highlightedItem.highlighted,
+    };
+
+    baskets[basketIndex].items[itemIndex] = highlightedItem;
+    baskets = baskets;
+  }
+
   function handleFoundItemClick(event, item, currBasketIndex, currItemIndex) {
     event.stopPropagation();
     selectedAvailableItem = {};
-    selectedFoundItem = {
-      ...item,
-      currBasketIndex,
-      currItemIndex,
-    };
+
+    if (selectedFoundItem?.id === item.id && selectedFoundItem?.currBasketIndex === currBasketIndex && selectedFoundItem?.currItemIndex === currItemIndex) {
+      // Highlight the item if they double click on the item
+      toggleHighlightItem(currBasketIndex, currItemIndex);
+      selectedFoundItem = {};
+    } else {
+      selectedFoundItem = {
+        ...item,
+        currBasketIndex,
+        currItemIndex,
+      };
+    }
   }
 
   function handleAvailableItemClick(event, item, currBasketIndex, currItemIndex) {
@@ -164,34 +185,16 @@
   }
 
   function handleClearItem(event, basketIndex, itemIndex) {
-    if (event.button === 1) {
-      event.preventDefault();
-
-      const [removedItem] = baskets[basketIndex].items.splice(itemIndex, 1);
-
-      updateRegionFoundFromRegionTransfer(removedItem, undefined, basketIndex);
-      baskets = baskets;
-
-      handleCheckToExposeRegion(baskets[basketIndex], baskets[REGIONS.length + 1], removedItem);
-      selectedAvailableItem = {};
-      selectedFoundItem = {};
-    }
-  }
-
-  function toggleHighlightItem(event, basketIndex, itemIndex) {
     event.preventDefault();
 
-    let highlightedItem = {
-      ...baskets[basketIndex].items[itemIndex],
-    };
+    const [removedItem] = baskets[basketIndex].items.splice(itemIndex, 1);
 
-    highlightedItem = {
-      ...highlightedItem,
-      highlighted: !highlightedItem.highlighted,
-    };
-
-    baskets[basketIndex].items[itemIndex] = highlightedItem;
+    updateRegionFoundFromRegionTransfer(removedItem, undefined, basketIndex);
     baskets = baskets;
+
+    handleCheckToExposeRegion(baskets[basketIndex], baskets[REGIONS.length + 1], removedItem);
+    selectedAvailableItem = {};
+    selectedFoundItem = {};
   }
 
   function assignToPokemon() {
@@ -299,8 +302,7 @@
               on:dragstart={(e) => dragStart(e, i, itemIndex)}
               on:click={(e) => handleFoundItemClick(e, item, i, itemIndex)}
               on:keypress={(e) => handleFoundItemClick(e, item, i, itemIndex)}
-              on:auxclick={(e) => handleClearItem(e, i, itemIndex)}
-              on:contextmenu={(e) => toggleHighlightItem(e, i, itemIndex)}
+              on:contextmenu={(e) => handleClearItem(e, i, itemIndex)}
             />
           {/each}
           {#if showSolution}


### PR DESCRIPTION
Right clicking a found item will now reset it back to its original home. (something the Classic tracker didn't have yet)
Double-left-clicking a found item will highlight it in a red border.