### PR TITLE
Account for National Park spoiler locations starting with 'Route_36'

### DIFF
--- a/src/constants/regions.js
+++ b/src/constants/regions.js
@@ -197,8 +197,8 @@ export const KOVOLTA_REGIONS = [
   {
     id: 2,
     name: 'Violet',
-    locations: ['Violet', 'Sprout_Tower'],
-    routes: [32, 36],
+    locations: ['Violet', 'Sprout_Tower', 'Route_36_East', 'Route_36_West'],
+    routes: [32],
     description: 'Violet + Rts 32, 36',
   },
   {
@@ -218,7 +218,7 @@ export const KOVOLTA_REGIONS = [
   {
     id: 5,
     name: 'Goldenrod',
-    locations: ['Goldenrod', 'Radio_Tower', 'National_Park'],
+    locations: ['Goldenrod', 'Radio_Tower', 'Route_36_National_Park'],
     routes: [35],
     description: 'Goldenrod, National Park + Rt 35',
   },


### PR DESCRIPTION
This is specifically for Kovolta's randomizer. Example location strings for Route 36 are:

`ROUTE_36_NATIONAL_PARK_GATE_CONTEST_1ST_PLACE_PRIZE`
`ROUTE_36_WEST_AREA_ALANS_GIFT`
`ROUTE_36_EAST_AREA_ROCK_SMASH_GUYS_GIFT`